### PR TITLE
Better add_msec_time handling

### DIFF
--- a/lib/fluent/plugin/out_gelf.rb
+++ b/lib/fluent/plugin/out_gelf.rb
@@ -62,7 +62,7 @@ class GELFOutput < BufferedOutput
       when 'msec' then
         # msec must be three digits (leading/trailing zeroes)
         if @add_msec_time then 
-          gelfentry[:timestamp] = (time.to_s + "." + v).to_f
+          gelfentry[:timestamp] = "#{time.to_s}.#{v}".to_f
         else
           gelfentry[:_msec] = v
         end


### PR DESCRIPTION
Avoiding "no implicit conversion of Fixnum into String" exception