### PR TITLE
Possibly fix issue with illegal UTF-8 messages

### DIFF
--- a/lib/fluent/plugin/out_gelf.rb
+++ b/lib/fluent/plugin/out_gelf.rb
@@ -67,9 +67,9 @@ class GELFOutput < BufferedOutput
           gelfentry[:_msec] = v
         end
       when 'short_message', 'full_message', 'facility', 'line', 'file' then
-        gelfentry[k] = v
+        gelfentry[k] = v.encode('UTF-8', {:invalid => :replace, :undef => :replace, :replace => '?'})
       else
-        gelfentry['_'+k] = v
+        gelfentry['_'+k] = v.encode('UTF-8', {:invalid => :replace, :undef => :replace, :replace => '?'})
       end
     end
 

--- a/lib/fluent/plugin/out_gelf.rb
+++ b/lib/fluent/plugin/out_gelf.rb
@@ -67,9 +67,17 @@ class GELFOutput < BufferedOutput
           gelfentry[:_msec] = v
         end
       when 'short_message', 'full_message', 'facility', 'line', 'file' then
-        gelfentry[k] = v.encode('UTF-8', {:invalid => :replace, :undef => :replace, :replace => '?'})
+        if v.kind_of?(String) then
+          gelfentry[k] = v.encode('UTF-8', {:invalid => :replace, :undef => :replace, :replace => '?'})
+        else
+          gelfentry[k] = v
+        end
       else
-        gelfentry['_'+k] = v.encode('UTF-8', {:invalid => :replace, :undef => :replace, :replace => '?'})
+        if v.kind_of?(String) then
+          gelfentry['_'+k] = v.encode('UTF-8', {:invalid => :replace, :undef => :replace, :replace => '?'})
+        else
+          gelfentry['_'+k] = v
+        end
       end
     end
 


### PR DESCRIPTION
I am not a Ruby developer, but I had an issue when messages contain 8-bit ASCII characters, like "\xC2". This made td-agent hang.

This change tries to fix the message.