### PR TITLE
Support Fluent::EventTime and increased timestamp precision

### DIFF
--- a/lib/fluent/plugin/out_gelf.rb
+++ b/lib/fluent/plugin/out_gelf.rb
@@ -45,7 +45,13 @@ class GELFOutput < BufferedOutput
   end
 
   def format(tag, time, record)
-    gelfentry = { :timestamp => time, :_tag => tag }
+    if time.is_a? Fluent::EventTime then
+      timestamp = time.sec + (time.nsec.to_f/1000000000).round(3)
+    else
+      timestamp = time
+    end
+
+    gelfentry = { :timestamp => timestamp, :_tag => tag }
 
     record.each_pair do |k,v|
       case k


### PR DESCRIPTION
Fluentd 0.14 introduced the Fluent::EventTime type to add nanosecond precision to fluentd messages, with the fields `sec`, representing the good old UNIX integer timestamps, and `nsec`, representing the nanoseconds to add on top of the regular UNIX timestamp.

The current GELF specification only supports milliseconds though, so we have to do some gymnastic to output a timestamp in GELF's float format of `<integer_timestamp>.<milliseconds>` and to keep supporting fluentd 0.12 which does not have the Fluent::EventTime type.