### PR TITLE
Fix the check on short_message always being set to something

### DIFF
--- a/lib/fluent/plugin/out_gelf.rb
+++ b/lib/fluent/plugin/out_gelf.rb
@@ -84,7 +84,7 @@ class GELFOutput < BufferedOutput
       end
     end
 
-    if !gelfentry.has_key?('short_message') then
+    if gelfentry['short_message'].to_s.empty? then
       gelfentry[:short_message] = record.to_json
     end
 


### PR DESCRIPTION
This PR aligns with https://github.com/Graylog2/gelf-rb/blob/master/lib/gelf/notifier.rb#L218-L224

Otherwise, fluent-plugin-gelf allows for empty strings to be passed down to gelf-fb, triggering exceptions and preventing messages to be properly processed.