### PR TITLE
0.14.7 compat: declare that format returns msgpack binary format

### DIFF
--- a/lib/fluent/plugin/out_gelf.rb
+++ b/lib/fluent/plugin/out_gelf.rb
@@ -103,6 +103,9 @@ class GELFOutput < BufferedOutput
     end
   end
 
+  def formatted_to_msgpack_binary
+    true
+  end
 end
 
 


### PR DESCRIPTION
Compatibility with fluent/fluentd#1263
Fixes emsearcy/fluent-plugin-gelf#24