### PR TITLE
fix emit transaction failed: error_class=NoMethodError for bytesize

### DIFF
--- a/lib/fluent/plugin/out_gelf.rb
+++ b/lib/fluent/plugin/out_gelf.rb
@@ -57,7 +57,7 @@ class GELFOutput < BufferedOutput
 
     record.each_pair do |k,v|
       # Truncate values longer than configured maximum
-      v = v.bytesize > @max_bytes ? "#{v.byteslice(0, @max_bytes - 3)}..." : v
+      v = (v.respond_to?(:bytesize) && v.bytesize > @max_bytes) ? "#{v.byteslice(0, @max_bytes - 3)}..." : v
 
       case k
       when 'version' then


### PR DESCRIPTION
2017-01-11 14:48:37 -0800 [warn]: emit transaction failed: error_class=NameError error="undefined local variable or method `bytesize' for #<Fluent::GELFOutput:0x002b23318f77d8>" tag="tw.onprem.prod2.app.pxy.server.ca_access"
  2017-01-11 14:48:37 -0800 [warn]: /etc/td-agent/plugin/out_gelf.rb:60:in `block in format'
  2017-01-11 14:48:37 -0800 [warn]: /etc/td-agent/plugin/out_gelf.rb:58:in `each_pair'
  2017-01-11 14:48:37 -0800 [warn]: /etc/td-agent/plugin/out_gelf.rb:58:in `format'
  2017-01-11 14:48:37 -0800 [warn]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.12.20/lib/fluent/output.rb:273:in `block in format_stream'
  2017-01-11 14:48:37 -0800 [warn]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.12.20/lib/fluent/event.rb:128:in `call'
  2017-01-11 14:48:37 -0800 [warn]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.12.20/lib/fluent/event.rb:128:in `block in each'
  2017-01-11 14:48:37 -0800 [warn]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.12.20/lib/fluent/event.rb:127:in `each'
  2017-01-11 14:48:37 -0800 [warn]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.12.20/lib/fluent/event.rb:127:in `each'
  2017-01-11 14:48:37 -0800 [warn]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.12.20/lib/fluent/output.rb:272:in `format_stream'
  2017-01-11 14:48:37 -0800 [warn]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.12.20/lib/fluent/output.rb:258:in `emit'
  2017-01-11 14:48:37 -0800 [warn]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.12.20/lib/fluent/output.rb:32:in `next'
  2017-01-11 14:48:37 -0800 [warn]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.12.20/lib/fluent/plugin/out_copy.rb:74:in `emit'
  2017-01-11 14:48:37 -0800 [warn]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.12.20/lib/fluent/event_router.rb:88:in `emit_stream'
  2017-01-11 14:48:37 -0800 [warn]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.12.20/lib/fluent/plugin/in_tail.rb:248:in `receive_lines'
  2017-01-11 14:48:37 -0800 [warn]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.12.20/lib/fluent/plugin/in_tail.rb:343:in `call'
  2017-01-11 14:48:37 -0800 [warn]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.12.20/lib/fluent/plugin/in_tail.rb:343:in `wrap_receive_lines'
  2017-01-11 14:48:37 -0800 [warn]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.12.20/lib/fluent/plugin/in_tail.rb:536:in `call'
  2017-01-11 14:48:37 -0800 [warn]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.12.20/lib/fluent/plugin/in_tail.rb:536:in `on_notify'
  2017-01-11 14:48:37 -0800 [warn]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.12.20/lib/fluent/plugin/in_tail.rb:369:in `on_notify'
  2017-01-11 14:48:37 -0800 [warn]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.12.20/lib/fluent/plugin/in_tail.rb:470:in `call'
  2017-01-11 14:48:37 -0800 [warn]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.12.20/lib/fluent/plugin/in_tail.rb:470:in `on_change'
  2017-01-11 14:48:37 -0800 [warn]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/cool.io-1.4.2/lib/cool.io/loop.rb:88:in `run_once'
  2017-01-11 14:48:37 -0800 [warn]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/cool.io-1.4.2/lib/cool.io/loop.rb:88:in `run'
  2017-01-11 14:48:37 -0800 [warn]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.12.20/lib/fluent/plugin/in_tail.rb:233:in `run'