### PR TITLE
Runtime deps

### DIFF
--- a/fluent-plugin-gelf.gemspec
+++ b/fluent-plugin-gelf.gemspec
@@ -18,7 +18,6 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency "fluentd"
   s.add_runtime_dependency "gelf"
-  s.add_runtime_dependency "string-scrub" if RUBY_VERSION.to_f < 2.1
   s.add_development_dependency "rake"
   s.add_development_dependency "test-unit"
 end

--- a/fluent-plugin-gelf.gemspec
+++ b/fluent-plugin-gelf.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_runtime_dependency "fluentd"
-  s.add_runtime_dependency "gelf"
+  s.add_runtime_dependency "gelf", ">= 2.0.0"
   s.add_development_dependency "rake"
   s.add_development_dependency "test-unit"
 end


### PR DESCRIPTION
This is part of what was in PR #34.  This changeset contains the needed changes to the runtime dependencies in the gemspec.

- remove string-scrub, since nothing in the content requires it
- add '>= 2.0.0' version specification for the gelf dependency, since this is when the TCP support was added. 