### PR TITLE
Add a Fluent GELF formatter plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,29 @@
-fluent-plugin-gelf
-==================
+# Fluentd GELF output and formatter plugins
+
+## Overview
+Fluentd GELF output and formatter plugins.
+
+## Installation
+```bash
+gem install fluent-plugin-gelf
+```
+
+## Output plugin configuration
+```
+<match **>
+  type gelf
+  host <remote GELF host>
+  port <remote GELF port>
+  protocol <tcp or udp (default)>
+  [ fluent buffered output plugin configuration ]
+</match>
+```
+
+## Formatter plugin configuration
+```
+<match **>
+  type file (any type that that takes a format argument)
+  format gelf
+  [ fluent file output plugin configuration ]
+</match>
+```

--- a/lib/fluent/gelf_util.rb
+++ b/lib/fluent/gelf_util.rb
@@ -20,25 +20,31 @@ module Fluent
             gelfentry['_host'] = v
           end
         when 'level' then
-          case v.to_s.downcase
+          case v.to_s.downcase[0]
           # emergency and alert aren't supported by gelf-rb
-          when /^(0|emerg)/ then
+          when "0" then
             gelfentry['level'] = GELF::UNKNOWN
-          when /^(1|a)/ then
+          when "1", "a" then
             gelfentry['level'] = GELF::UNKNOWN
-          when /^(2|c)/ then
+          when "2", "c" then
             gelfentry['level'] = GELF::FATAL
-          when /^(3|e)/ then
+          when "3" then
             gelfentry['level'] = GELF::ERROR
-          when /^(4|w)/ then
+          when "4", "w" then
             gelfentry['level'] = GELF::WARN
           # gelf-rb also skips notice
-          when /^(5|n)/ then
+          when "5", "n" then
             gelfentry['level'] = GELF::INFO
-          when /^(6|i)/ then
+          when "6", "i" then
             gelfentry['level'] = GELF::INFO
-          when /^(7|d)/ then
+          when "7", "d" then
             gelfentry['level'] = GELF::DEBUG
+          when "e" then
+            if v.to_s.length >= 2 and v.to_s.downcase[1] != "r" then
+              gelfentry['level'] = GELF::UNKNOWN
+            else
+              gelfentry['level'] = GELF::ERROR
+            end
           else
             gelfentry['_level'] = v
           end

--- a/lib/fluent/gelf_util.rb
+++ b/lib/fluent/gelf_util.rb
@@ -1,0 +1,74 @@
+module Fluent
+  module GelfUtil
+
+    require 'gelf'
+
+    def make_gelfentry(tag,time,record, conf = {})
+      gelfentry = { 'timestamp' => time, '_tag' => tag }
+
+      record.each_pair do |k,v|
+        case k
+        when 'host' then
+          if conf[:use_record_host] then
+            gelfentry['host'] = v
+          else
+            gelfentry['_host'] = v
+          end
+        when 'level' then
+          case v.to_s.downcase
+          # emergency and alert aren't supported by gelf-rb
+          when /^(0|emerg)/ then
+            gelfentry['level'] = GELF::UNKNOWN
+          when /^(1|a)/ then
+            gelfentry['level'] = GELF::UNKNOWN
+          when /^(2|c)/ then
+            gelfentry['level'] = GELF::FATAL
+          when /^(3|e)/ then
+            gelfentry['level'] = GELF::ERROR
+          when /^(4|w)/ then
+            gelfentry['level'] = GELF::WARN
+          # gelf-rb also skips notice
+          when /^(5|n)/ then
+            gelfentry['level'] = GELF::INFO
+          when /^(6|i)/ then
+            gelfentry['level'] = GELF::INFO
+          when /^(7|d)/ then
+            gelfentry['level'] = GELF::DEBUG
+          else
+            gelfentry['_level'] = v
+          end
+        when 'msec' then
+          # msec must be three digits (leading/trailing zeroes)
+          if conf[:add_msec_time] then
+            gelfentry['timestamp'] = "#{time.to_s}.#{v}".to_f
+          else
+            gelfentry['_msec'] = v
+          end
+        when 'short_message', 'full_message', 'facility', 'line', 'file' then
+          gelfentry[k] = v
+        else
+          gelfentry['_'+k] = v
+        end
+      end
+
+      if gelfentry['short_message'].nil? or gelfentry['short_message'].empty? then
+        if not (gelfentry['_message'].nil? or gelfentry['_message'].empty?) then
+          gelfentry['short_message'] = gelfentry.delete('_message')
+        else
+          gelfentry['short_message'] = record.to_json
+        end
+      end
+
+      # I realize the nulls are will be treated as unset keys, but it does
+      # tend to make for larger files and data transmissions.
+      return gelfentry.delete_if{ |k,v| v.nil? }
+
+    end
+
+    def make_json(gelfentry,conf)
+      gelfentry['version'] = '1.0'
+
+      gelfentry.to_json + ( conf.is_a?(Hash) and conf.key?(:record_separator) ? conf[:record_separator] : "\0" )
+    end
+  end
+end

--- a/lib/fluent/gelf_util.rb
+++ b/lib/fluent/gelf_util.rb
@@ -4,7 +4,12 @@ module Fluent
     require 'gelf'
 
     def make_gelfentry(tag,time,record, conf = {})
-      gelfentry = { 'timestamp' => time, '_tag' => tag }
+      gelfentry = { '_tag' => tag }
+      if defined? Fluent::EventTime and time.is_a? Fluent::EventTime then
+        gelfentry['timestamp'] = time.sec + (time.nsec.to_f/1000000000).round(3)
+      else
+        gelfentry['timestamp'] = time
+      end
 
       record.each_pair do |k,v|
         case k
@@ -51,11 +56,19 @@ module Fluent
         end
       end
 
-      if gelfentry['short_message'].nil? or gelfentry['short_message'].empty? then
-        if not (gelfentry['_message'].nil? or gelfentry['_message'].empty?) then
+      if !gelfentry.key?('short_message') or gelfentry['short_message'].to_s.empty? then
+        # allow other non-empty fields to masquerade as the short_message if it is unset
+        if gelfentry.key?('_message') and !gelfentry['_message'].to_s.empty? then
           gelfentry['short_message'] = gelfentry.delete('_message')
+        elsif gelfentry.key?('_msg') and !gelfentry['_msg'].to_s.empty? then
+          gelfentry['short_message'] = gelfentry.delete('_msg')
+        elsif gelfentry.key?('_log') and !gelfentry['_log'].to_s.empty? then
+          gelfentry['short_message'] = gelfentry.delete('_log')
+        elsif gelfentry.key?('_record') and !gelfentry['_record'].to_s.empty? then
+          gelfentry['short_message'] = gelfentry.delete('_record')
         else
-          gelfentry['short_message'] = record.to_json
+          # we must have a short_message, so provide placeholder
+          gelfentry['short_message'] = '(no message)'
         end
       end
 

--- a/lib/fluent/plugin/formatter_gelf.rb
+++ b/lib/fluent/plugin/formatter_gelf.rb
@@ -1,0 +1,75 @@
+require 'fluent/formatter'
+
+module Fluent
+  module TextFormatter
+    class GELFFormatter < Formatter
+      Plugin.register_formatter("gelf", self)
+
+      config_param :use_record_host, :bool, :default => true
+      config_param :add_msec_time, :bool, :default => false
+
+      def configure(conf)
+        super(conf)
+        require 'gelf'
+      end
+
+      def format(tag, time, record)
+        gelfentry = {
+            :timestamp => time,
+            :protocol => 1,
+            :version => "1.0",
+            :_tag => tag
+        }
+
+        record.each_pair do |k,v|
+          case k
+          when 'tag' then
+            gelfentry[:_tag] = v
+          when 'version' then
+            gelfentry[:_version] = v
+          when 'timestamp' then
+            gelfentry[:_timestamp] = v
+          when 'host' then
+            if @use_record_host then gelfentry[:host] = v
+            else gelfentry[:_host] = v end
+          when 'level' then
+            case "#{v}".downcase
+            # emergency and alert aren't supported by gelf-rb
+            when '0', 'emergency' then gelfentry[:level] = GELF::UNKNOWN
+            when '1', 'alert' then gelfentry[:level] = GELF::UNKNOWN
+            when '2', 'critical', 'crit' then gelfentry[:level] = GELF::FATAL
+            when '3', 'error', 'err' then gelfentry[:level] = GELF::ERROR
+            when '4', 'warning', 'warn' then gelfentry[:level] = GELF::WARN
+            # gelf-rb also skips notice
+            when '5', 'notice' then gelfentry[:level] = GELF::INFO
+            when '6', 'informational', 'info' then gelfentry[:level] = GELF::INFO
+            when '7', 'debug' then gelfentry[:level] = GELF::DEBUG
+            else gelfentry[:_level] = v
+            end
+          when 'msec' then
+            # msec must be three digits (leading/trailing zeroes)
+            if @add_msec_time then 
+              gelfentry[:timestamp] = "#{time.to_s}.#{v}".to_f
+            else
+              gelfentry[:_msec] = v
+            end
+          when 'short_message', 'full_message', 'facility', 'line', 'file' then
+            gelfentry[k] = v
+          else
+            gelfentry['_'+k] = v
+          end
+        end
+  
+        if !gelfentry.has_key?('short_message') then
+          if record.has_key?('message') then
+            gelfentry[:short_message] = record['message']
+          else
+            gelfentry[:short_message] = record.to_json
+          end
+        end
+        return gelfentry.to_json + "\0"
+      end
+
+    end
+  end
+end

--- a/lib/fluent/plugin/formatter_gelf.rb
+++ b/lib/fluent/plugin/formatter_gelf.rb
@@ -3,71 +3,29 @@ require 'fluent/formatter'
 module Fluent
   module TextFormatter
     class GELFFormatter < Formatter
+
       Plugin.register_formatter("gelf", self)
+
+      require 'fluent/gelf_util'
+      include GelfUtil
 
       config_param :use_record_host, :bool, :default => true
       config_param :add_msec_time, :bool, :default => false
 
       def configure(conf)
         super(conf)
-        require 'gelf'
       end
 
       def format(tag, time, record)
-        gelfentry = {
-            :timestamp => time,
-            :protocol => 1,
-            :version => "1.0",
-            :_tag => tag
-        }
+        gelfentry = make_gelfentry(
+          tag,time,record,
+          {
+            :use_record_host => @use_record_host,
+            :add_msec_time => @add_msec_time
+          }
+        )
 
-        record.each_pair do |k,v|
-          case k
-          when 'tag' then
-            gelfentry[:_tag] = v
-          when 'version' then
-            gelfentry[:_version] = v
-          when 'timestamp' then
-            gelfentry[:_timestamp] = v
-          when 'host' then
-            if @use_record_host then gelfentry[:host] = v
-            else gelfentry[:_host] = v end
-          when 'level' then
-            case "#{v}".downcase
-            # emergency and alert aren't supported by gelf-rb
-            when '0', 'emergency' then gelfentry[:level] = GELF::UNKNOWN
-            when '1', 'alert' then gelfentry[:level] = GELF::UNKNOWN
-            when '2', 'critical', 'crit' then gelfentry[:level] = GELF::FATAL
-            when '3', 'error', 'err' then gelfentry[:level] = GELF::ERROR
-            when '4', 'warning', 'warn' then gelfentry[:level] = GELF::WARN
-            # gelf-rb also skips notice
-            when '5', 'notice' then gelfentry[:level] = GELF::INFO
-            when '6', 'informational', 'info' then gelfentry[:level] = GELF::INFO
-            when '7', 'debug' then gelfentry[:level] = GELF::DEBUG
-            else gelfentry[:_level] = v
-            end
-          when 'msec' then
-            # msec must be three digits (leading/trailing zeroes)
-            if @add_msec_time then 
-              gelfentry[:timestamp] = "#{time.to_s}.#{v}".to_f
-            else
-              gelfentry[:_msec] = v
-            end
-          when 'short_message', 'full_message', 'facility', 'line', 'file' then
-            gelfentry[k] = v
-          else
-            gelfentry['_'+k] = v
-          end
-        end
-  
-        if !gelfentry.has_key?('short_message') then
-          if record.has_key?('message') then
-            gelfentry[:short_message] = record['message']
-          else
-            gelfentry[:short_message] = record.to_json
-          end
-        end
-        return gelfentry.to_json + "\0"
+        make_json(gelfentry,{})
       end
 
     end


### PR DESCRIPTION
Nothing is changed in the existing content, except for the README.md in order to document usage.  This is part of what originally had bundled up in PR #34.  The formatter plugin is implemented using a GelfUtil module, with the intention of converting the existing output plugin to use this shared functionality to make things more maintainable.  I've removed the regexes from the event "level" parsing.  One major change with the implementation of the GelfUtil module was to standardize on hashes with string keys, since JSON cannot serialize Ruby symbols.