### PR TITLE
add in support for multi-workers

### DIFF
--- a/lib/fluent/plugin/out_gelf.rb
+++ b/lib/fluent/plugin/out_gelf.rb
@@ -15,6 +15,10 @@ class GELFOutput < BufferedOutput
     require "gelf"
   end
 
+  def multi_workers_ready?
+    true
+  end
+
   def configure(conf)
     super
 


### PR DESCRIPTION
Add in support for multi-process workers. The buffered input class will automatically detect workers and create the appropriate buffer dir. IE `/path/to/buffer/dir/worker0` if buffer dir is `/path/to/buffer/dir`. 

Tested this locally on my env without any issues